### PR TITLE
Add PHP 7.x Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: ["master"]
+    branches: [ "master" ]
   pull_request:
-    branches: ["master"]
+    branches: [ "master" ]
 
 permissions:
   contents: read
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["7.4", "8.1", "8.2"]
+        php-version: ['7.4', '8.1', '8.2']
     steps:
       - uses: actions/checkout@v4
       - name: Use PHP ${{ matrix.php-version }}
@@ -54,8 +54,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["7.4", "8.1", "8.2"]
-        version: ["dev-master", "1.0"]
+        php-version: ['7.4', '8.1', '8.2']
+        version: ['dev-master', '1.0']
     steps:
       - uses: actions/checkout@v4
       - name: Use PHP ${{ matrix.php-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 7.4
         php-version: ["7.4", "8.1", "8.2"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 permissions:
   contents: read
@@ -20,7 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.2']
+        # 7.4
+        php-version: ["7.4", "8.1", "8.2"]
     steps:
       - uses: actions/checkout@v4
       - name: Use PHP ${{ matrix.php-version }}
@@ -54,8 +55,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.2']
-        version: ['dev-master', '1.0']
+        php-version: ["7.4", "8.1", "8.2"]
+        version: ["dev-master", "1.0"]
     steps:
       - uses: actions/checkout@v4
       - name: Use PHP ${{ matrix.php-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+**.sarif

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "SARIF formatter for PHPStan",
   "license": "MIT",
   "require": {
-    "php": "^8.1",
+    "php": "^7.4 || ^8.1",
     "nette/utils": "^3.0 || ^4.0",
     "phpstan/phpstan": "^1.9"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,33 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "44919bd6ab17a1eba265db0de5ccedbe",
+    "content-hash": "70ce0ad08a67415cc4452346d8e29f08",
     "packages": [
         {
             "name": "nette/utils",
-            "version": "v4.0.5",
+            "version": "v3.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96"
+                "reference": "a4175c62652f2300c8017fb7e640f9ccb11648d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
-                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
+                "url": "https://api.github.com/repos/nette/utils/zipball/a4175c62652f2300c8017fb7e640f9ccb11648d2",
+                "reference": "a4175c62652f2300c8017fb7e640f9ccb11648d2",
                 "shasum": ""
             },
             "require": {
-                "php": "8.0 - 8.4"
+                "php": ">=7.2 <8.4"
             },
             "conflict": {
-                "nette/finder": "<3",
-                "nette/schema": "<1.2.2"
+                "nette/di": "<3.0.6"
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "dev-master",
-                "nette/tester": "^2.5",
+                "nette/tester": "~2.0",
                 "phpstan/phpstan": "^1.0",
-                "tracy/tracy": "^2.9"
+                "tracy/tracy": "^2.3"
             },
             "suggest": {
                 "ext-gd": "to use Image",
@@ -39,12 +38,13 @@
                 "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
                 "ext-json": "to use Nette\\Utils\\Json",
                 "ext-mbstring": "to use Strings::lower() etc...",
-                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()"
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()",
+                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -88,22 +88,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.5"
+                "source": "https://github.com/nette/utils/tree/v3.2.10"
             },
-            "time": "2024-08-07T15:39:19+00:00"
+            "time": "2023-07-30T15:38:18+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.3",
+            "version": "1.12.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "0fcbf194ab63d8159bb70d9aa3e1350051632009"
+                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0fcbf194ab63d8159bb70d9aa3e1350051632009",
-                "reference": "0fcbf194ab63d8159bb70d9aa3e1350051632009",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
+                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
                 "shasum": ""
             },
             "require": {
@@ -148,18 +148,18 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-09T08:10:35+00:00"
+            "time": "2024-10-18T11:12:07+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^7.4 || ^8.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/src/SarifErrorFormatter.php
+++ b/src/SarifErrorFormatter.php
@@ -13,106 +13,113 @@ use PHPStan\Internal\ComposerHelper;
 
 class SarifErrorFormatter implements ErrorFormatter
 {
+    private const URI_BASE_ID = 'WORKINGDIR';
 
-  private const URI_BASE_ID = 'WORKINGDIR';
+    // Declare properties
+    private RelativePathHelper $relativePathHelper;
+    private string $currentWorkingDirectory;
+    private bool $pretty;
 
-  public function __construct(
-    private RelativePathHelper $relativePathHelper,
-    private string $currentWorkingDirectory,
-    private bool $pretty,
-  ) {
-  }
+    public function __construct(
+        RelativePathHelper $relativePathHelper,
+        string $currentWorkingDirectory,
+        bool $pretty
+    ) {
+        $this->relativePathHelper = $relativePathHelper;
+        $this->currentWorkingDirectory = $currentWorkingDirectory;
+        $this->pretty = $pretty;
+    }
 
-  public function formatErrors(AnalysisResult $analysisResult, Output $output): int
-  {
-    $phpstanVersion = ComposerHelper::getPhpStanVersion();
+    public function formatErrors(AnalysisResult $analysisResult, Output $output): int
+    {
+        $phpstanVersion = ComposerHelper::getPhpStanVersion();
 
-    $tool = [
-      'driver' => [
-        'name' => 'PHPStan',
-        'fullName' => 'PHP Static Analysis Tool',
-        'informationUri' => 'https://phpstan.org',
-        'version' => $phpstanVersion,
-        'semanticVersion' => $phpstanVersion,
-        'rules' => [],
-      ],
-    ];
-
-    $originalUriBaseIds = [
-      self::URI_BASE_ID => [
-        'uri' => 'file://' . $this->currentWorkingDirectory . '/',
-      ],
-    ];
-
-    $results = [];
-
-    foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
-      $result = [
-        'level' => 'error',
-        'message' => [
-          'text' => $fileSpecificError->getMessage(),
-        ],
-        'locations' => [
-          [
-            'physicalLocation' => [
-              'artifactLocation' => [
-                'uri' => $this->relativePathHelper->getRelativePath($fileSpecificError->getFile()),
-                'uriBaseId' => self::URI_BASE_ID,
-              ],
-              'region' => [
-                'startLine' => $fileSpecificError->getLine(),
-              ],
+        $tool = [
+            'driver' => [
+                'name' => 'PHPStan',
+                'fullName' => 'PHP Static Analysis Tool',
+                'informationUri' => 'https://phpstan.org',
+                'version' => $phpstanVersion,
+                'semanticVersion' => $phpstanVersion,
+                'rules' => [],
             ],
-          ],
-        ],
-        'properties' => [
-          'ignorable' => $fileSpecificError->canBeIgnored(),
-          // 'identifier' => $fileSpecificError->getIdentifier(),
-          // 'metadata' => $fileSpecificError->getMetadata(),
-        ],
-      ];
+        ];
 
-      if ($fileSpecificError->getTip() !== null) {
-        $result['properties']['tip'] = $fileSpecificError->getTip();
-      }
+        $originalUriBaseIds = [
+            self::URI_BASE_ID => [
+                'uri' => 'file://' . $this->currentWorkingDirectory . '/',
+            ],
+        ];
 
-      $results[] = $result;
+        $results = [];
+
+        foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
+            $result = [
+                'level' => 'error',
+                'message' => [
+                    'text' => $fileSpecificError->getMessage(),
+                ],
+                'locations' => [
+                    [
+                        'physicalLocation' => [
+                            'artifactLocation' => [
+                                'uri' => $this->relativePathHelper->getRelativePath($fileSpecificError->getFile()),
+                                'uriBaseId' => self::URI_BASE_ID,
+                            ],
+                            'region' => [
+                                'startLine' => $fileSpecificError->getLine(),
+                            ],
+                        ],
+                    ],
+                ],
+                'properties' => [
+                    'ignorable' => $fileSpecificError->canBeIgnored(),
+                    // 'identifier' => $fileSpecificError->getIdentifier(),
+                    // 'metadata' => $fileSpecificError->getMetadata(),
+                ],
+            ];
+
+            if ($fileSpecificError->getTip() !== null) {
+                $result['properties']['tip'] = $fileSpecificError->getTip();
+            }
+
+            $results[] = $result;
+        }
+
+        foreach ($analysisResult->getNotFileSpecificErrors() as $notFileSpecificError) {
+            $results[] = [
+                'level' => 'error',
+                'message' => [
+                    'text' => $notFileSpecificError,
+                ],
+            ];
+        }
+
+        foreach ($analysisResult->getWarnings() as $warning) {
+            $results[] = [
+                'level' => 'warning',
+                'message' => [
+                    'text' => $warning,
+                ],
+            ];
+        }
+
+        $sarif = [
+            '$schema' => 'https://json.schemastore.org/sarif-2.1.0.json',
+            'version' => '2.1.0',
+            'runs' => [
+                [
+                    'tool' => $tool,
+                    'originalUriBaseIds' => $originalUriBaseIds,
+                    'results' => $results,
+                ],
+            ],
+        ];
+
+        $json = Json::encode($sarif, $this->pretty ? Json::PRETTY : 0);
+
+        $output->writeRaw($json);
+
+        return $analysisResult->hasErrors() ? 1 : 0;
     }
-
-    foreach ($analysisResult->getNotFileSpecificErrors() as $notFileSpecificError) {
-      $results[] = [
-        'level' => 'error',
-        'message' => [
-          'text' => $notFileSpecificError,
-        ],
-      ];
-    }
-
-    foreach ($analysisResult->getWarnings() as $warning) {
-      $results[] = [
-        'level' => 'warning',
-        'message' => [
-          'text' => $warning,
-        ],
-      ];
-    }
-
-    $sarif = [
-      '$schema' => 'https://json.schemastore.org/sarif-2.1.0.json',
-      'version' => '2.1.0',
-      'runs' => [
-        [
-          'tool' => $tool,
-          'originalUriBaseIds' => $originalUriBaseIds,
-          'results' => $results,
-        ],
-      ],
-    ];
-
-    $json = Json::encode($sarif, $this->pretty ? Json::PRETTY : 0);
-
-    $output->writeRaw($json);
-
-    return $analysisResult->hasErrors() ? 1 : 0;
-  }
-}
+} // Ensure this closing brace is present


### PR DESCRIPTION
I've experimented with this change in my ~4000 file PHP 7.4 project and it ran.

- adds compatibility for PHP 7.x while maintaining the newer features in PHP 8 when available.
- the Local tests ran in my fork and updated the Code Scanning page with the failing tests.
- this downgraded `nette/utils` in the composer.lock. Is there a better way to do this that doesn't force the downgrade?

If you don't want the `nette/utils` downgrade, I'm perfectly fine with documenting something like this, which I think will allow it to work for 7.4 projects.

`composer require --dev --ignore-platform-reqs jbelien/phpstan-sarif-formatter nette/utils:3.2.10`